### PR TITLE
Open store for writing review on iOS

### DIFF
--- a/src/ios/AppReviewPlugin.m
+++ b/src/ios/AppReviewPlugin.m
@@ -20,12 +20,19 @@
     if ([packageName isKindOfClass:[NSNull class]]) {
         packageName = [[NSBundle mainBundle] infoDictionary][@"CFBundleIdentifier"];
     }
+    BOOL writeReview = [[command.arguments objectAtIndex:1] boolValue];
     NSString* trackId = [self fetchTrackId:packageName];
 
     CDVPluginResult* pluginResult;
     if (trackId) {
         NSString* storeURL = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@", trackId];
-        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeURL] options:@{} completionHandler:nil];
+        NSString* storeReviewURL = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@?action=write-review", trackId];
+
+        if (writeReview) {
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeReviewURL] options:@{} completionHandler:nil];
+        } else {
+            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeURL] options:@{} completionHandler:nil];
+        }
 
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {

--- a/src/ios/AppReviewPlugin.m
+++ b/src/ios/AppReviewPlugin.m
@@ -26,13 +26,12 @@
     CDVPluginResult* pluginResult;
     if (trackId) {
         NSString* storeURL = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@", trackId];
-        NSString* storeReviewURL = [NSString stringWithFormat:@"https://apps.apple.com/app/id%@?action=write-review", trackId];
 
         if (writeReview) {
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeReviewURL] options:@{} completionHandler:nil];
-        } else {
-            [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeURL] options:@{} completionHandler:nil];
+            storeURL = [NSString stringWithFormat:@"%@?action=write-review", storeURL];
         }
+        
+        [[UIApplication sharedApplication] openURL:[NSURL URLWithString:storeURL] options:@{} completionHandler:nil];
 
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK];
     } else {

--- a/www/AppReview.js
+++ b/www/AppReview.js
@@ -27,15 +27,16 @@ exports.openStoreScreen =
  * is displayed but you can pass a package name string to show another app details.
  *
  * @param {string} [packageName] Package name to show instead of the current app.
+ * @param {boolean} [writeReview] Open review form if true. Only implemented on iOS.
  * @returns {Promise<void>} Callback when operation is completed
  *
  * @example
  * cordova.plugins.AppReview.openStoreScreen();
  * cordova.plugins.AppReview.openStoreScreen("com.app.example");
+ * cordova.plugins.AppReview.openStoreScreen(null, true);
  */
-function(packageName) {
+function(packageName, writeReview) {
     return new Promise(function(resolve, reject) {
-        var writeReview = true;
-        exec(resolve, reject, PLUGIN_NAME, "openStoreScreen", [packageName || null, writeReview]);
+        exec(resolve, reject, PLUGIN_NAME, "openStoreScreen", [packageName || null, writeReview || false]);
     });
 };

--- a/www/AppReview.js
+++ b/www/AppReview.js
@@ -35,6 +35,7 @@ exports.openStoreScreen =
  */
 function(packageName) {
     return new Promise(function(resolve, reject) {
-        exec(resolve, reject, PLUGIN_NAME, "openStoreScreen", [packageName || null]);
+        var writeReview = true;
+        exec(resolve, reject, PLUGIN_NAME, "openStoreScreen", [packageName || null, writeReview]);
     });
 };


### PR DESCRIPTION
- add: on iOS calling openStoreScreen does not open the write review form as the documentation states that it should; according to Apples documentation a query param must be added to actually open the review

See: https://developer.apple.com/documentation/storekit/requesting_app_store_reviews?language=objc

Closes #5 